### PR TITLE
Add links to FAQ and note about high support load

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -32,6 +32,13 @@
                     <div class="mt-1"></div>
                 </div>
                 <mat-divider></mat-divider>
+                <div class="text-left" translate>
+                    Zur Zeit gibt es ein erhöhtes Anfrageaufkommen.
+                    Um Ihnen und Anderen schneller weiterhelfen zu können, schauen Sie bitte zuerst in unsere
+                    <strong><a href="https://support.openslides.com/help/de-de">FAQs</a></strong>
+                    und nutzen dann bevorzugt die Möglichkeit uns eine E-Mail zu senden.
+                </div>
+                <div class="mt-1"></div>
                 <div fxLayout="row" fxLayout.lt-md="row wrap" fxLayoutAlign="space-between" appWrappable
                     wrapMarginY="35px">
                     <div fxFlex="27" fxFlex.lt-md="100%" class="text-left">

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -15,6 +15,8 @@
                     class="os-button transparent-btn blue"><span translate>Demo</span></a>
                 <a routerLink="/" fragment="getting-started" mat-flat-button
                     class="os-button transparent-btn green"><span translate>Hosting starten</span></a>
+                <a href="https://support.openslides.com/help/" target="_blank" rel="noreferrer" mat-flat-button
+                   class="os-button transparent-btn blue"><span translate>FAQ</span></a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
 * Add prominent link to FAQ in the top beside Hosting and Demo in the alternating color.
 * Add simple text indicating that there are many request and users should first look into our FAQ and then prefer email.