### PR TITLE
Add hosting start date

### DIFF
--- a/api/src/templates/order-summary.jinja
+++ b/api/src/templates/order-summary.jinja
@@ -2,12 +2,13 @@ _{{ _("Hostingauswahl") }}
 {{ _("Hostingpaket") }}: {{ package_str }}
 {{ _("Hostinglaufzeit") }}: {{ running_time_str }}
 {{ _("Wunschdomain") }}: {% if domain %}https://{{ domain }}.openslides.com/{% else %}-{% endif %}
-{{ _("Zusatzfunktionen") }}: {% if extra_functions_str %}{{ extra_functions_str }}{% else %}{{ _("keine") }}{% endif %}
+{% if hosting_start %}{{ _("Startdatum Hosting") }}: {{ hosting_start }}
+{% endif %}{{ _("Zusatzfunktionen") }}: {% if extra_functions_str %}{{ extra_functions_str }}{% else %}{{ _("keine") }}{% endif %}
 
 _{{ _("Veranstaltungsdetails") }}
 {{ _("Veranstaltungsname") }}: {{ event_name }}
 {{ _("Veranstaltungsort") }}: {{ event_location }}
-{{ _("Veranstaltungszeitraum") }}: {{ event_from }} - {{ event_to }}
+{{ _("Veranstaltungstage(e)") }}: {{ event_from }} - {{ event_to }}
 {{ _("Erwartete Teilnehmeranzahl") }}: {{ expected_users }}
 
 _{{ _("Ansprechpartner") }}

--- a/api/src/validation.py
+++ b/api/src/validation.py
@@ -3,7 +3,7 @@ from jsonschema import Draft7Validator, draft7_format_checker
 from .data import get_extra_functions, get_packages, get_services
 
 
-standard_pattern = r"^[A-Za-z0-9\u00C0-\u00FF][A-Za-z0-9\u00C0-\u00FF\'\-\.\,\#]+([\ A-Za-z0-9\u00C0-\u00FF][A-Za-z0-9\u00C0-\u00FF\'\-\.\,\#]+)*$"
+standard_pattern = r"^([A-Za-z0-9\u00C0-\u00FF][A-Za-z0-9\u00C0-\u00FF\'\-\.\,\#]+([\ A-Za-z0-9\u00C0-\u00FF][A-Za-z0-9\u00C0-\u00FF\'\-\.\,\#]+)*)?$"
 standard_pattern_no_number = r"^[A-Za-z\u00C0-\u00FF][A-Za-z\u00C0-\u00FF\'\-\.\,\#]+([\ A-Za-z\u00C0-\u00FF][A-Za-z\u00C0-\u00FF\'\-\.\,\#]+)*$"
 domain_regex = r"^[a-zA-Z0-9\-\.]*$"
 date_regex = r"^\d{4}-\d{2}-\d{2}$"
@@ -33,16 +33,32 @@ base_schema = Draft7Validator(
                     if not function.get("hidden")
                 ),
             },
-            "event_name": {"type": "string", "pattern": standard_pattern},
-            "event_location": {"type": "string", "pattern": standard_pattern},
+            "event_name": {
+                "type": "string",
+                "pattern": standard_pattern,
+                "minLength": 1,
+            },
+            "event_location": {
+                "type": "string",
+                "pattern": standard_pattern,
+                "minLength": 1,
+            },
             "event_from": {"type": "string", "pattern": date_regex},
             "event_to": {"type": "string", "pattern": date_regex},
             "expected_users": {"type": "integer", "min": 0},
             "contact_person": {
                 "type": "object",
                 "properties": {
-                    "organisation": {"type": "string", "pattern": standard_pattern},
-                    "name": {"type": "string", "pattern": standard_pattern_no_number},
+                    "organisation": {
+                        "type": "string",
+                        "pattern": standard_pattern,
+                        "minLength": 1,
+                    },
+                    "name": {
+                        "type": "string",
+                        "pattern": standard_pattern_no_number,
+                        "minLength": 1,
+                    },
                     "email": {"type": "string", "format": "email"},
                     "phone": {
                         "type": "string",
@@ -96,10 +112,18 @@ order_schema = {
         "tax_id": {"type": "string"},
         "billing_address": {
             "type": "object",
+            "properties": {
+                "name": {"type": "string", "minLength": 1},
+                "street": {"type": "string", "minLength": 1},
+                "zip": {"type": "string", "minLength": 1},
+                "city": {"type": "string", "minLength": 1},
+                "country": {"type": "string", "minLength": 1},
+            },
             "required": ["name", "street", "zip", "city", "country"],
         },
+        "hosting_start": {"type": "string", "pattern": date_regex},
     },
-    "required": ["domain", "billing_address"],
+    "required": ["domain", "billing_address", "hosting_start"],
 }
 
 mail_schema = Draft7Validator(

--- a/scripts/send-dummy-order.sh
+++ b/scripts/send-dummy-order.sh
@@ -10,11 +10,12 @@ curl --header "Content-Type: application/json" -e "https://www.openslides.com/$l
     "package": "conference",
     "running_time": "unlimited",
     "domain": "xyz",
+    "hosting_start": "2022-01-01",
     "extra_functions": {
         "audio": false,
         "video": true,
         "external_video": false,
-        "saml": true,
+        "saml": false,
         "service": true
     },
     "services": {

--- a/src/app/order/order.component.html
+++ b/src/app/order/order.component.html
@@ -105,10 +105,18 @@
                 <mat-form-field>
                     <input required type="text" matInput formControlName="event_location" placeholder="{{ 'Veranstaltungsort' | translate}}">
                 </mat-form-field>
-                <mat-form-field>
+                <mat-form-field class="mb-0">
                     <input [required]="!isOffer" type="text" matInput formControlName="domain" placeholder="{{ 'Wunschdomain' | translate }}">
                     <span matSuffix>.openslides.com</span>
                     <mat-hint *ngIf="detailsForm.controls.domain.value && detailsForm.controls.domain.valid">https://{{detailsForm.controls.domain.value}}.openslides.com/</mat-hint>
+                </mat-form-field>
+                <mat-form-field *ngIf="!isOffer">
+                    <mat-label>
+                        <span translate>Startdatum Hosting</span>
+                    </mat-label>
+                    <input matInput class="ng-trim-ignore" required formControlName="hosting_start" readonly [min]="today" (focus)="hosting_start_picker.open()" (click)="hosting_start_picker.open()" [matDatepicker]="hosting_start_picker">
+                    <mat-datepicker-toggle matSuffix [for]="hosting_start_picker"></mat-datepicker-toggle>
+                    <mat-datepicker #hosting_start_picker></mat-datepicker>
                 </mat-form-field>
 
                 <h3 class="mb-0" translate>Ansprechpartner</h3>
@@ -230,7 +238,7 @@
                             </td>
                             <td colspan="2">
                                 <button mat-flat-button class="os-button" [disabled]="hostingDataForm.invalid" (click)="nextStep(2)">
-                                    <span translate>Jetzt bestellen</span>
+                                    <span translate>Weiter zur Bestellung</span>
                                 </button>
                             </td>
                         </ng-container>
@@ -261,6 +269,11 @@
                     <tr *ngIf="overviewData.isUnlimited">
                         <td colspan="5">
                             ³&nbsp;<i translate>Preis für 12 Monate, beliebig verlängerbar.</i>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan="5">
+                           <p><i translate>Für gemeinnützige Organisationen gibt es auf Anfrage 20% Rabatt auf das Hosting. Bitte im Kommentarfeld unter "zusätzliche Angaben" beantragen und kurz begründen.</i></p>
                         </td>
                     </tr>
                 </table>


### PR DESCRIPTION
Also fixes an error where the billing address was mandatory even for offers.

A few notes:
- I moved the form input into the second form instead of directly below the hosting running time to keep the initial price calculator as simple as possible (the start time is not needed for price calculation)
- I set the minimum and default value to the current date, but IMO it should be tomorrow (like we have for the event start date)
- I removed the input for the offer form since it doesn't seem intuitive to be able to give a start date when you just want to get an offer

Another side note, when first filling out the price calculator, the order button says "Order now", which makes it seem like you would order it directly instead of directing you to the next page. Maybe we should change the wording here.